### PR TITLE
param keys are sym not strings

### DIFF
--- a/lib/pushbullet_ruby/pushable/file.rb
+++ b/lib/pushbullet_ruby/pushable/file.rb
@@ -12,7 +12,7 @@ module PushbulletRuby
               file_name: data['file_name'],
               file_type: data['file_type'],
               file_url:  data['file_url'],
-              body:      params['body'],
+              body:      params[:body],
               type:      type
           }
 


### PR DESCRIPTION
file pushes don't include text (params['body'] is nil, value is in params[:body])